### PR TITLE
Improve update check parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4734,6 +4734,7 @@ dependencies = [
  "rodio",
  "rstest",
  "rustrict",
+ "semver",
  "serde",
  "serde_test",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ splines = "5.0.0"
 clap = { version = "4.5.39", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["macros"] }
 async-channel = "2.3.1"
+semver = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 gag = "1.0.0"

--- a/src/utils/check_updates.rs
+++ b/src/utils/check_updates.rs
@@ -1,5 +1,6 @@
-use crate::SNIFFNET_LOWERCASE;
 use crate::utils::formatted_strings::APP_VERSION;
+use crate::SNIFFNET_LOWERCASE;
+use semver::Version;
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -48,23 +49,18 @@ async fn is_newer_release_available(max_retries: u8, seconds_between_retries: u8
             .name;
         latest_version = latest_version.trim().to_string();
 
-        // release name sample: v1.1.2
-        // TODO: support versions with numbers of more than 1 digit
-        let latest_version_as_bytes = latest_version.as_bytes();
-        if latest_version.len() == 6
-            && latest_version.starts_with('v')
-            && char::from(latest_version_as_bytes[1]).is_numeric()
-            && char::from(latest_version_as_bytes[2]).eq(&'.')
-            && char::from(latest_version_as_bytes[3]).is_numeric()
-            && char::from(latest_version_as_bytes[4]).eq(&'.')
-            && char::from(latest_version_as_bytes[5]).is_numeric()
-        {
-            latest_version.remove(0);
-            return if latest_version.gt(&APP_VERSION.to_string()) {
-                Some(true)
-            } else {
-                Some(false)
-            };
+        // release name sample: v1.2.3
+        if let Some(stripped) = latest_version.strip_prefix('v') {
+            if let (Ok(latest_semver), Ok(current_semver)) = (
+                Version::parse(stripped),
+                Version::parse(APP_VERSION),
+            ) {
+                return if latest_semver > current_semver {
+                    Some(true)
+                } else {
+                    Some(false)
+                };
+            }
         }
     }
     let retries_left = max_retries - 1;


### PR DESCRIPTION
## Summary
- compare releases with the `semver` crate
- add `semver` to dependencies

## Testing
- `cargo check` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*
- `cargo test -q` *(fails: pkg-config couldn't find `alsa`)*

------
https://chatgpt.com/codex/tasks/task_e_6865592688588328be524accef5821cd